### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,3 @@
+language = "python3"
+  run = "INSTALL PACKAGES.bat"
+  

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 -- BIG credits to xMistt for the source code and inspiration of this bot.
-
+[![Run on Repl.it](https://repl.it/badge/github/Keanuofficial/bot)](https://repl.it/github/Keanuofficial/bot)
 # fortnitepy-bot
 A fortnite XMPP bot coded in Python with party capabilites.
 


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).